### PR TITLE
60-day lookback window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 
 settings.py
+scratch/

--- a/common-upgrade-alerts.ipynb
+++ b/common-upgrade-alerts.ipynb
@@ -27,6 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from datetime import datetime, timedelta\n",
     "from settings import OBSERVATORIUM_URL, OBSERVATORIUM_AUTH_COOKIE\n",
     "from urllib.parse import quote\n",
     "import requests"
@@ -38,11 +39,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "observatorium_query = OBSERVATORIUM_URL + \"/query?query=\" + quote(\"sre:slo:upgradeoperator_upgrade_result == 0\")\n",
+    "range_start = int((datetime.now() - timedelta(days=60)).timestamp())\n",
+    "range_end = int(datetime.now().timestamp())\n",
+    "observatorium_query = f\"{OBSERVATORIUM_URL}/query_range?start={range_start}&end={range_end}&step=3600&query={quote('sre:slo:upgradeoperator_upgrade_result == 0')}\"\n",
     "observatorium_results = requests.get(observatorium_query, cookies=OBSERVATORIUM_AUTH_COOKIE).json()\n",
     "if observatorium_results['status'] != \"success\":\n",
     "    raise ValueError(\"Observatorium query unsuccessful: \" + str(observatorium_results))\n",
-    "alerting_upgrade_cluster_uuids = set(r['metric']['_id'] for r in observatorium_results['data']['result'])"
+    "alerting_upgrade_cluster_uuids = set(r['metric']['_id'] for r in observatorium_results['data']['result'])\n",
+    "len(alerting_upgrade_cluster_uuids)\n",
+    "observatorium_results"
    ]
   },
   {
@@ -60,7 +65,7 @@
    "outputs": [],
    "source": [
     "import re\n",
-    "from datetime import datetime, timezone\n",
+    "from datetime import timezone\n",
     "from util import OCMClient"
    ]
   },
@@ -100,7 +105,8 @@
     "        'upgrade_start': upgrade_start,\n",
     "        'upgrade_end': upgrade_end\n",
     "    }\n",
-    "    upgrade_window_dicts.append(window_dict)"
+    "    upgrade_window_dicts.append(window_dict)\n",
+    "len(upgrade_window_dicts)"
    ]
   },
   {
@@ -151,7 +157,8 @@
     "                    'cluster_uuid': uwd['uuid']\n",
     "                })\n",
     "            except KeyError as ex:\n",
-    "                print(f\"WARN: Couldn't process alert due to missing {ex}: {tr['metric']}\")"
+    "                print(f\"WARN: Couldn't process alert due to missing {ex}: {tr['metric']}\")\n",
+    "len(alert_dicts)"
    ]
   },
   {
@@ -189,7 +196,8 @@
    "outputs": [],
    "source": [
     "histogram = alerts_df.value_counts(subset=[\"name\", \"severity\", \"namespace\"]).to_frame().reset_index()\n",
-    "histogram[histogram['severity'] == \"critical\"]"
+    "pd.set_option('display.max_rows', 260)\n",
+    "histogram #[histogram['severity'] == \"critical\"]"
    ]
   }
  ],


### PR DESCRIPTION
This PR modifies the first step of the notebook (identifying clusters that had a "failed" upgrade) such that it finds clusters that experienced such an upgrade within the last 60 days